### PR TITLE
Normalize discovered schema relation endpoint type casing

### DIFF
--- a/src/sift_kg/domains/discovery.py
+++ b/src/sift_kg/domains/discovery.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 _SAMPLE_MAX_CHARS = 3000
 
 
+def _normalize_type_names(values: list[str] | None) -> list[str]:
+    """Normalize entity type names from LLM output to uppercase identifiers."""
+    if not values:
+        return []
+    return [str(value).upper() for value in values if str(value).strip()]
+
+
 def build_discovery_prompt(
     samples: list[str],
     system_context: str = "",
@@ -112,8 +119,8 @@ async def discover_domain(
         elif isinstance(cfg, dict):
             relation_types[name.upper()] = RelationTypeConfig(
                 description=cfg.get("description", ""),
-                source_types=cfg.get("source_types", []),
-                target_types=cfg.get("target_types", []),
+                source_types=_normalize_type_names(cfg.get("source_types", [])),
+                target_types=_normalize_type_names(cfg.get("target_types", [])),
                 symmetric=cfg.get("symmetric", False),
             )
 

--- a/src/sift_kg/domains/loader.py
+++ b/src/sift_kg/domains/loader.py
@@ -17,6 +17,13 @@ logger = logging.getLogger(__name__)
 # Bundled domains directory (shipped with the package)
 BUNDLED_DOMAINS_DIR = Path(__file__).parent / "bundled"
 
+
+def _normalize_type_names(values: list[str] | None) -> list[str]:
+    """Normalize relation endpoint type names to uppercase identifiers."""
+    if not values:
+        return []
+    return [str(value).upper() for value in values if str(value).strip()]
+
 # Module-level loader for convenience function
 _default_loader: "DomainLoader | None" = None
 
@@ -133,8 +140,8 @@ class DomainLoader:
             else:
                 relation_types[name] = RelationTypeConfig(
                     description=cfg.get("description", ""),
-                    source_types=cfg.get("source_types", []),
-                    target_types=cfg.get("target_types", []),
+                    source_types=_normalize_type_names(cfg.get("source_types", [])),
+                    target_types=_normalize_type_names(cfg.get("target_types", [])),
                     symmetric=cfg.get("symmetric", False),
                     extraction_hints=cfg.get("extraction_hints", []),
                     review_required=cfg.get("review_required", False),

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -7,11 +7,14 @@ import yaml
 
 from sift_kg.domains.discovery import (
     build_discovery_prompt,
+    discover_domain,
     load_discovered_domain,
     save_discovered_domain,
 )
 from sift_kg.domains.loader import DomainLoader, load_domain
 from sift_kg.domains.models import DomainConfig, EntityTypeConfig, RelationTypeConfig
+from sift_kg.graph.knowledge_graph import KnowledgeGraph
+from sift_kg.graph.postprocessor import fix_relation_directions
 
 
 class TestDomainModels:
@@ -106,6 +109,30 @@ class TestDomainLoader:
         assert "ANIMAL" in domain.entity_types
         assert "LIVES_IN" in domain.relation_types
 
+    def test_load_from_custom_yaml_normalizes_relation_endpoint_types(self, tmp_dir):
+        """Lowercase source/target type names are normalized on load."""
+        yaml_content = {
+            "name": "Custom Domain",
+            "entity_types": {
+                "PERSON": {"description": "A person"},
+                "COMPANY": {"description": "A company"},
+            },
+            "relation_types": {
+                "WORKS_FOR": {
+                    "description": "Employment",
+                    "source_types": ["person"],
+                    "target_types": ["company"],
+                },
+            },
+        }
+        yaml_path = tmp_dir / "custom.yaml"
+        yaml_path.write_text(yaml.dump(yaml_content))
+
+        loader = DomainLoader()
+        domain = loader.load_from_path(yaml_path)
+        assert domain.relation_types["WORKS_FOR"].source_types == ["PERSON"]
+        assert domain.relation_types["WORKS_FOR"].target_types == ["COMPANY"]
+
     def test_load_from_nonexistent_path(self):
         """Loading from missing path raises error."""
         loader = DomainLoader()
@@ -176,6 +203,56 @@ class TestDiscovery:
         prompt = build_discovery_prompt([long_sample])
         # The prompt should contain at most 3000 x's from the sample
         assert prompt.count("x") <= 3000
+
+    @pytest.mark.asyncio
+    async def test_discover_domain_normalizes_relation_endpoint_types_for_direction_fixing(self):
+        """Discovered schemas use uppercase endpoints so direction fixing can work."""
+
+        class FakeLLM:
+            async def acall_json(self, prompt):
+                return {
+                    "entity_types": {
+                        "person": {"description": "A person"},
+                        "company": {"description": "A company"},
+                    },
+                    "relation_types": {
+                        "works_for": {
+                            "description": "Employment",
+                            "source_types": ["person"],
+                            "target_types": ["company"],
+                        },
+                    },
+                }
+
+        domain = await discover_domain(["Alice works for Acme."], FakeLLM())
+
+        kg = KnowledgeGraph()
+        kg.add_entity("person:alice", "PERSON", "Alice")
+        kg.add_entity("company:acme", "COMPANY", "Acme")
+        kg.add_relation(
+            "r1",
+            "company:acme",
+            "person:alice",
+            "WORKS_FOR",
+            canonicalize=False,
+        )
+
+        stats = fix_relation_directions(
+            kg,
+            {
+                "WORKS_FOR": (
+                    domain.relation_types["WORKS_FOR"].source_types,
+                    domain.relation_types["WORKS_FOR"].target_types,
+                    False,
+                )
+            },
+        )
+
+        assert domain.relation_types["WORKS_FOR"].source_types == ["PERSON"]
+        assert domain.relation_types["WORKS_FOR"].target_types == ["COMPANY"]
+        assert stats["relations_flipped"] == 1
+        assert kg.graph.has_edge("person:alice", "company:acme")
+        assert not kg.graph.has_edge("company:acme", "person:alice")
 
     def test_save_and_load_roundtrip(self, tmp_dir):
         """Saving a DomainConfig and loading it back produces equivalent data."""


### PR DESCRIPTION
## What changed
- Normalize `source_types` and `target_types` to uppercase when building a discovered domain from LLM output.
- Apply the same normalization when loading domain YAML so previously discovered schemas and hand-written custom domains are treated consistently.
- Add regression coverage for the schema-free discovery path and YAML loading path.

## Insight / Why this matters
The discovery flow already uppercases entity type names and relation names, but it previously kept relation endpoint type lists exactly as returned by the LLM.

That mismatch is easy to miss because the discovered schema still looks structurally valid, and most tests/use cases start from bundled YAML that is already uppercase. But downstream direction-fixing logic compares extracted entity types case-sensitively against `source_types` / `target_types`.

In practice, if the LLM returns `person` / `company` while the graph contains `PERSON` / `COMPANY`, reversed relations are silently left uncorrected even though the schema has enough information to fix them.

This patch fixes the root cause at schema construction time and also hardens YAML loading for existing/custom schemas. Scope is rollback-safe: only relation endpoint normalization changes, with no broader extraction or graph format changes.

## Necessity / Harm Prevented
What breaks today:
- Schema-free discovery can produce relation endpoint types whose casing does not match extracted entity types.
- That prevents post-processing from correcting relation direction when the extracted edge is backwards.

Who is harmed:
- Users relying on auto-discovered schemas or custom YAML with lowercase endpoint types.
- Their resulting knowledge graph can keep semantically reversed edges, which is a correctness issue rather than a cosmetic one.

Why this is necessary:
- The bug causes silently wrong graph structure in a path that is meant to improve extraction quality automatically.
- The fix is small, deterministic, and covered by regression tests.

## Testing
- `pytest -q tests/test_domains.py`
- `pytest -q`
